### PR TITLE
Update tox to include Django 1.11, Python 3.6.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35}-django{18,19,110,111}
+envlist = py27-django{18,19,110,111},py{34,35,36}-django{18,19,110,111,20}
+skip_missing_interpreters = True
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
     python manage.py test
 deps =
-    Jinja2==2.8
+    Jinja2==2.9.4
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
-    django111: https://codeload.github.com/django/django/zip/master
+    django111: Django>=1.11a,<2.0
+    django20: https://codeload.github.com/django/django/zip/master


### PR DESCRIPTION
Separates Django 1.11 and 2.0 as test. Adds Python 3.6 (although Travis doesn't seem to support this yet...)