### PR TITLE
Support for RequestContext during block rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ next (xxx xx, xxxx)
 
 *   Supports Django 1.11, Django 2.1, and Django 2.2.
 *   Supports Python 2.7, 3.5, 3.6, and 3.7.
+*   ``render_block_to_string`` now optionally accepts a ``request`` parameter.
+    If given a ``RequestContext`` instead of a ``Context`` is used when
+    rendering with the Django templating engine. See #15, thanks to @vintage.
 
 0.5 (September 1, 2016)
 =======================

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ API Reference
 
 The API is simple and attempts to mirror the built-in ``render_to_string`` API.
 
-``render_block_to_string(template_name, block_name, context=None)``
+``render_block_to_string(template_name, block_name, context=None, request=None)``
 
     ``template_name``
         The name of the template to load and render. If it’s a list of template
@@ -83,6 +83,13 @@ The API is simple and attempts to mirror the built-in ``render_to_string`` API.
 
         ``context`` is now optional. An empty context will be used if it isn’t
         provided.
+
+    ``request``
+        The request object used to render the template.
+
+        ``request`` is optional and works only for Django templates.
+        Standard ``Context` instead of ``RequestContext`` will be used if
+        it isn’t provided.
 
 Exceptions
 ----------

--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,8 @@ The API is simple and attempts to mirror the built-in ``render_to_string`` API.
     ``request``
         The request object used to render the template.
 
-        ``request`` is optional and works only for Django templates.
-        Standard ``Context` instead of ``RequestContext`` will be used if
-        it isn’t provided.
+        ``request`` is optional and works only for Django templates. If
+        provided a ``RequestContext`` will be used instead of a ``Context``.
 
 Exceptions
 ----------

--- a/render_block/base.py
+++ b/render_block/base.py
@@ -14,7 +14,7 @@ from render_block.django import django_render_block
 from render_block.exceptions import BlockNotFound, UnsupportedEngine
 
 
-def render_block_to_string(template_name, block_name, context=None):
+def render_block_to_string(template_name, block_name, context=None, request=None):
     """
     Loads the given template_name and renders the given block with the given
     dictionary as context. Returns a string.
@@ -36,7 +36,7 @@ def render_block_to_string(template_name, block_name, context=None):
 
     # The Django backend.
     if isinstance(t, DjangoTemplate):
-        return django_render_block(t, block_name, context)
+        return django_render_block(t, block_name, context, request)
 
     elif isinstance(t, Jinja2Template):
         from render_block.jinja2 import jinja2_render_block

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from django.template import Context, RequestContext
 from django.template.base import TextNode
 from django.template.context import make_context
 from django.template.loader_tags import (BLOCK_CONTEXT_KEY,
@@ -10,9 +11,13 @@ from django.template.loader_tags import (BLOCK_CONTEXT_KEY,
 from render_block.exceptions import BlockNotFound
 
 
-def django_render_block(template, block_name, context):
+def django_render_block(template, block_name, context, request=None):
     # Create a Django Context.
-    context_instance = make_context(dict(context), request=context.get('request'))
+    if request:
+        context_instance = RequestContext(request)
+        context_instance.push(context)
+    else:
+        context_instance = Context(context)
 
     # Get the underlying django.template.base.Template object.
     template = template.template

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-from django.template import Context, RequestContext
 from django.template.base import TextNode
-from django.template.context import make_context
+from django.template.context import Context, RequestContext
 from django.template.loader_tags import (BLOCK_CONTEXT_KEY,
                                          BlockContext,
                                          BlockNode,

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
+from django.template import Context, RequestContext
 from django.template.base import TextNode
-from django.template.context import Context, RequestContext
 from django.template.loader_tags import (BLOCK_CONTEXT_KEY,
                                          BlockContext,
                                          BlockNode,

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -13,8 +13,7 @@ from render_block.exceptions import BlockNotFound
 def django_render_block(template, block_name, context, request=None):
     # Create a Django Context.
     if request:
-        context_instance = RequestContext(request)
-        context_instance.push(context)
+        context_instance = RequestContext(request, context)
     else:
         context_instance = Context(context)
 

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from django.template import Context
 from django.template.base import TextNode
+from django.template.context import make_context
 from django.template.loader_tags import (BLOCK_CONTEXT_KEY,
                                          BlockContext,
                                          BlockNode,
@@ -12,7 +12,7 @@ from render_block.exceptions import BlockNotFound
 
 def django_render_block(template, block_name, context):
     # Create a Django Context.
-    context_instance = Context(context)
+    context_instance = make_context(dict(context), request=context.get('request'))
 
     # Get the underlying django.template.base.Template object.
     template = template.template

--- a/tests/templates/test_request_context.html
+++ b/tests/templates/test_request_context.html
@@ -1,0 +1,3 @@
+{% include 'test1.html' %}
+
+{% block block1 %}{{ request.path }}{% endblock %}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,6 @@
 from unittest import skip
 
-from django.template import Context
-from django.test import override_settings, TestCase
+from django.test import override_settings, TestCase, RequestFactory
 from django.utils import six
 
 from render_block import render_block_to_string, BlockNotFound, UnsupportedEngine
@@ -98,6 +97,13 @@ class TestDjango(TestCase):
             render_block_to_string('test1.html', 'noblock')
         self.assertExceptionMessageEquals(exc.exception,
                                           "Can only render blocks from the Django template backend.")
+
+    def test_request_context(self):
+        """Test that a request context data are properly rendered in a template."""
+        request = RequestFactory().get('dummy-url')
+        result = render_block_to_string('test_request_context.html', 'block1', {}, request)
+
+        self.assertEqual(result, u'/dummy-url')
 
 
 @override_settings(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,6 @@
 from unittest import skip
 
-from django.test import override_settings, TestCase, RequestFactory
+from django.test import modify_settings, override_settings, TestCase, RequestFactory
 from django.utils import six
 
 from render_block import render_block_to_string, BlockNotFound, UnsupportedEngine
@@ -98,6 +98,14 @@ class TestDjango(TestCase):
         self.assertExceptionMessageEquals(exc.exception,
                                           "Can only render blocks from the Django template backend.")
 
+    @modify_settings(
+        INSTALLED_APPS={
+            'prepend': [
+                'django.contrib.auth',
+                'django.contrib.contenttypes',
+            ],
+        },
+    )
     def test_request_context(self):
         """Test that a request context data are properly rendered in a template."""
         request = RequestFactory().get('dummy-url')


### PR DESCRIPTION
The current implementation hard-codes use of the `Context` instance, but lots of apps are using `RequestContext` instead - https://docs.djangoproject.com/en/2.0/ref/templates/api/#django.template.RequestContext

Refactor context creation to take into account, that both classes are supported by using Django built-in method called `make_context`.