### PR TITLE
Forward Context instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ next (xxx xx, xxxx)
 *   Supports Django 1.11, Django 2.1, and Django 2.2.
 *   Supports Python 2.7, 3.5, 3.6, and 3.7.
 *   ``render_block_to_string`` now optionally accepts a ``request`` parameter.
-    If given a ``RequestContext`` instead of a ``Context`` is used when
+    If given, a ``RequestContext`` instead of a ``Context`` is used when
     rendering with the Django templating engine. See
     `#15 <https://github.com/clokep/django-render-block/pull/15>`_, thanks to
     @vintage.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+next (xxx xx, xxxx)
+===================
+
+*   ``render_block_to_string`` now forwards the ``Context`` passed as ``context`` parameter.
+    (`#21 <https://github.com/clokep/django-render-block/pull/21>`_, by @bblanchon)
+
 0.7 (July 13, 2020)
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ The API is simple and attempts to mirror the built-in ``render_to_string`` API.
         The request object used to render the template.
 
         ``request`` is optional and works only for Django templates. If
-        provided a ``RequestContext`` will be used instead of a ``Context``.
+        provided, a ``RequestContext`` will be used instead of a ``Context``.
 
 Exceptions
 ----------

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ The API is simple and attempts to mirror the built-in ``render_to_string`` API.
         The name of the block to render from the above template.
 
     ``context``
-        A ``dict`` to be used as the template’s context for rendering.
+        A ``dict`` or a ``Context`` to be used as the template’s context for rendering.
 
         ``context`` is now optional. An empty context will be used if it isn’t
         provided.

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -9,8 +9,10 @@ from render_block.exceptions import BlockNotFound
 
 
 def django_render_block(template, block_name, context, request=None):
-    # Create a Django Context.
-    if request:
+    # Create a Django Context if needed
+    if isinstance(context, Context):
+        context_instance = context
+    elif request:
         context_instance = RequestContext(request, context)
     else:
         context_instance = Context(context)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -81,7 +81,7 @@ class TestDjango(TestCase):
         self.assertEqual(result, data)
 
     def test_context_autoescape_off(self):
-        """Test that the use can disable autoescape by providing a Context instance."""
+        """Test that the user can disable autoescape by providing a Context instance."""
         data = "&'"
         result = render_block_to_string('test5.html', 'block2', Context({'foo': data}, autoescape=False))
         self.assertEqual(result, data)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import skip
 
+from django.template import Context
 from django.test import modify_settings, override_settings, TestCase, RequestFactory
 
 from render_block import render_block_to_string, BlockNotFound, UnsupportedEngine
@@ -77,6 +78,12 @@ class TestDjango(TestCase):
         """Test that a context is properly rendered in a template."""
         data = 'block2 from test5'
         result = render_block_to_string('test5.html', 'block2', {'foo': data})
+        self.assertEqual(result, data)
+
+    def test_context_autoescape_off(self):
+        """Test that the use can disable autoescape by providing a Context instance."""
+        data = "&'"
+        result = render_block_to_string('test5.html', 'block2', Context({'foo': data}, autoescape=False))
         self.assertEqual(result, data)
 
     @override_settings(


### PR DESCRIPTION
This pull request makes `render_block_to_string()` forwards the `Context` instance provided by the user.

For example, this allows the user to disable autoescape, like so:

```python
result = render_block_to_string(template, block, Context(context, autoescape=False))
```

Such a feature is handy when rendering a text-only template, like an email or a notification message.