### PR TITLE
fix: corrected setup.cfg (resolves #34)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ classifiers =
     License :: OSI Approved :: ISC License (ISCL)
 
 [options]
-package = find:
+packages =
+    render_block
 install_requires = django>=2.2
 python_requires = >=3.6
 


### PR DESCRIPTION
The `package = find:` line in setup.cfg should have been `packages = find:`, but that would have also included tests since this repo is not currently using a [src layout](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#using-a-src-layout).  Resolves #34 