### PR TITLE
Django nodes cache

### DIFF
--- a/render_block/django.py
+++ b/render_block/django.py
@@ -1,5 +1,6 @@
 from copy import copy
 
+from django.conf import settings
 from django.template import Context, RequestContext
 from django.template.base import TextNode
 from django.template.context import RenderContext
@@ -54,7 +55,9 @@ def django_render_block(template, block_name, context, request=None):
 
                 # Check the parent template for this block.
                 node, render_context = _find_template_block(parent_template, block_name, context_instance)
-            _NODES_CACHE[cache_key] = node, render_context
+
+            if not settings.DEBUG:
+                _NODES_CACHE[cache_key] = node, render_context
 
         context_instance.render_context = render_context
         return node.render(context_instance)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,6 +4,7 @@ from django.template import Context
 from django.test import RequestFactory, TestCase, modify_settings, override_settings
 
 from render_block import BlockNotFound, UnsupportedEngine, render_block_to_string
+from render_block.django import _NODES_CACHE
 
 
 class TestDjango(TestCase):
@@ -141,6 +142,14 @@ class TestDjango(TestCase):
         )
 
         self.assertEqual(result, "/dummy-url")
+
+    def test_node_cache(self):
+        """Test rendering from cache."""
+        render_block_to_string("test1.html", "block1")
+        _NODES_CACHE["test1.html@fakeblock"] = _NODES_CACHE["test1.html@block1"]
+        result = render_block_to_string("test1.html", "fakeblock")
+        self.assertEqual(result, "block1 from test1")
+
 
 
 @override_settings(


### PR DESCRIPTION
It is really slow to parse templates everytime you call `render_block` and it is a static information, so you can cache it in memory.

I did some benchmarking here and this node cache improved performance ~20%.

Most work was done by @walison17, I just wrote a test and did the benckmark.