### PR TITLE
Support modern Python & Django.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: python -m pip install pyupgrade==2.31.1 flake8==4.0.1 black==22.3.0 isort==5.10.1
 
       - name: "Run pyupgrade"
-        run: pyupgrade --py37-plus **/*.py
+        run: pyupgrade --py38-plus **/*.py
 
       - name: "Run flake8"
         run: flake8
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,17 @@
 Changelog
 #########
 
+next
+====
+
+Maintenance
+-----------
+
+* Support Python 3.11. (`#44 <https://github.com/clokep/django-render-block/pull/44>`_)
+* Drop support for Python 3.7. (`#44 <https://github.com/clokep/django-render-block/pull/44>`_)
+* Support Django 4.2. (`#44 <https://github.com/clokep/django-render-block/pull/44>`_)
+* Drop support for Django < 3.2; Django 4.0. (`#44 <https://github.com/clokep/django-render-block/pull/44>`_)
+
 0.9.2 (October 18, 2022)
 ========================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ author = Patrick Cloke
 author_email = clokep@patrick.cloke.us
 url = https://github.com/clokep/django-render-block
 keywords = [django, template, block, templates, render, context]
+license = ISC
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
@@ -15,16 +17,13 @@ classifiers =
     Environment :: Web Environment
     Topic :: Internet
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: ISC License (ISCL)
 project_urls =
     Documentation = https://github.com/clokep/django-render-block/blob/main/README.rst
@@ -35,8 +34,8 @@ project_urls =
 [options]
 packages =
     render_block
-install_requires = django>=2.2
-python_requires = >=3.7
+install_requires = django>=3.2
+python_requires = >=3.8
 
 [options.extras_require]
 dev =

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,9 @@
 
 [tox]
 envlist =
-    py{37,38,39}-django{22,31,32},
-    # Django 3.2.9 added support for Python 3.10.
-    py310-django32,
-    # Django 4.0 drops support for Python 3.7.
-    py{38,39,310}-django{40,41,main}
+    py{38,39,310}-django{32,41,42,main},
+    # Django 4.1.3 adds support for Python 3.11.
+    py311-django{41,42,main}
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -21,6 +19,6 @@ deps =
     django22: Django>=2.2,<2.3
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     djangomain: https://codeload.github.com/django/django/zip/main


### PR DESCRIPTION
Drop Pythpn 3.7; add 3.11.

Drop old Django LTS; add 4,2.