### PR TITLE
Handles edge case where custom template tag defines child_nodelist at…

### DIFF
--- a/render_block/django.py
+++ b/render_block/django.py
@@ -106,6 +106,8 @@ def _render_template_block_nodelist(nodelist, block_name, context):
         for attr in node.child_nodelists:
             try:
                 new_nodelist = getattr(node, attr)
+                if new_nodelist is None:
+                    raise AttributeError()
             except AttributeError:
                 continue
 

--- a/tests/templates/test_none_nodelist.html
+++ b/tests/templates/test_none_nodelist.html
@@ -1,0 +1,5 @@
+{% load tests_tags %}
+
+{% none_nodelist %}
+
+{% block block1 %}block1 from test_none_nodelist{% endblock %}

--- a/tests/templatetags/tests_tags.py
+++ b/tests/templatetags/tests_tags.py
@@ -1,0 +1,14 @@
+from django import template
+from django.template.base import Node
+
+register = template.Library()
+
+
+def none_nodelist(parser, token):
+    node = Node()
+    for attr in node.child_nodelists:
+        setattr(node, attr, None)
+    return node
+
+
+register.tag("none_nodelist", none_nodelist)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -144,8 +144,9 @@ class TestDjango(TestCase):
 
     def test_none_nodelist(self):
         """
-        Test that a template containing a template tag which defines child_nodelist attributes as None before the
-        desired block is found will still properly find and render the desired block.
+        Test that a template containing a template tag which defines child_nodelist
+        attributes as None before the desired block is found will still properly
+        find and render the desired block.
         """
         result = render_block_to_string("test_none_nodelist.html", "block1")
         self.assertEqual(result, "block1 from test_none_nodelist")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -142,6 +142,14 @@ class TestDjango(TestCase):
 
         self.assertEqual(result, "/dummy-url")
 
+    def test_none_nodelist(self):
+        """
+        Test that a template containing a template tag which defines child_nodelist attributes as None before the
+        desired block is found will still properly find and render the desired block.
+        """
+        result = render_block_to_string("test_none_nodelist.html", "block1")
+        self.assertEqual(result, "block1 from test_none_nodelist")
+
 
 @override_settings(
     TEMPLATES=[


### PR DESCRIPTION
…tr as None

Absolutely love the library. I've recently discovered django-render-block is incompatible with django-slippers.

When a template tag is encountered before finding our desired block and that template tag defines its `child_nodelist` attributes as `None`, the rendering blows up [here](https://github.com/clokep/django-render-block/blob/main/render_block/django.py#L94) since `None` is not iterable.

Since standard Django procedure is to create an empty `NodeList` and extend it when parsing, I'd say the onus of this should be put on the custom template tag definition to _not_ set child nodelists to `None`. And I have opened a PR in the django-slippers repo as well. That said, I can't think of a side effect of including this here and it does handle the edge case where the attribute is explicitly defined as `None`.