### PR TITLE
Support multiple levels of extends.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Bugfixes
 
 * Fixes exception propagation when rendering templates. Contributed
   by `@yaakovLowenstein <https://github.com/yaakovLowenstein>`_. (`#52 <https://github.com/clokep/django-render-block/pull/52>`_)
-
+* Fix rendering blocks over multiple extended templates. (`#56 <https://github.com/clokep/django-render-block/pull/56>`_)
 
 Maintenance
 -----------

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -50,7 +50,9 @@ def django_render_block(
 
 
 def _build_block_context(template: Template, context: Context) -> None:
-    """Populate the block context with BlockNodes from this template and parent templates."""
+    """
+    Populate the block context with BlockNodes from this template and parent templates.
+    """
 
     # Ensure there's a BlockContext before rendering. This allows blocks in
     # ExtendsNodes to be found by sub-templates (allowing {{ block.super }} and

--- a/render_block/django.py
+++ b/render_block/django.py
@@ -4,7 +4,7 @@ from typing import Optional
 from django.http import HttpRequest
 from django.template import Context, RequestContext
 from django.template.backends.django import Template as DjangoTemplate
-from django.template.base import NodeList, Template, TextNode
+from django.template.base import Template
 from django.template.context import RenderContext
 from django.template.loader_tags import (
     BLOCK_CONTEXT_KEY,
@@ -44,25 +44,13 @@ def django_render_block(
         with context_instance.bind_template(template):
             # Before trying to render the template, we need to traverse the tree of
             # parent templates and find all blocks in them.
-            parent_template = _build_block_context(template, context_instance)
+            _build_block_context(template, context_instance)
 
-            try:
-                return _render_template_block(template, block_name, context_instance)
-            except BlockNotFound:
-                # The block wasn't found in the current template.
-
-                # If there's no parent template (i.e. no ExtendsNode), re-raise.
-                if not parent_template:
-                    raise
-
-                # Check the parent template for this block.
-                return _render_template_block(
-                    parent_template, block_name, context_instance
-                )
+            return _render_template_block(block_name, context_instance)
 
 
-def _build_block_context(template: Template, context: Context) -> Optional[Template]:
-    """Populate the block context with BlockNodes from parent templates."""
+def _build_block_context(template: Template, context: Context) -> None:
+    """Populate the block context with BlockNodes from this template and parent templates."""
 
     # Ensure there's a BlockContext before rendering. This allows blocks in
     # ExtendsNodes to be found by sub-templates (allowing {{ block.super }} and
@@ -71,68 +59,25 @@ def _build_block_context(template: Template, context: Context) -> Optional[Templ
         context.render_context[BLOCK_CONTEXT_KEY] = BlockContext()
     block_context = context.render_context[BLOCK_CONTEXT_KEY]
 
-    for node in template.nodelist:
-        if isinstance(node, ExtendsNode):
-            compiled_parent = node.get_parent(context)
+    # Add the template's blocks to the context.
+    block_context.add_blocks(
+        {n.name: n for n in template.nodelist.get_nodes_by_type(BlockNode)}
+    )
 
-            # Add the parent node's blocks to the context. (This ends up being
-            # similar logic to ExtendsNode.render(), where we're adding the
-            # parent's blocks to the context so a child can find them.)
-            block_context.add_blocks(
-                {
-                    n.name: n
-                    for n in compiled_parent.nodelist.get_nodes_by_type(BlockNode)
-                }
-            )
+    # Check parent nodes (there should only ever be 0 or 1).
+    for node in template.nodelist.get_nodes_by_type(ExtendsNode):
+        parent = node.get_parent(context)
 
-            _build_block_context(compiled_parent, context)
-            return compiled_parent
-
-        # The ExtendsNode has to be the first non-text node.
-        if not isinstance(node, TextNode):
-            break
-
-    return None
+        # Recurse and search for blocks from the parent.
+        _build_block_context(parent, context)
 
 
-def _render_template_block(
-    template: Template, block_name: str, context: Context
-) -> str:
+def _render_template_block(block_name: str, context: Context) -> str:
     """Renders a single block from a template."""
-    return _render_template_block_nodelist(template.nodelist, block_name, context)
+    block_node = context.render_context[BLOCK_CONTEXT_KEY].get_block(block_name)
 
+    if block_node is None:
+        # The wanted block_name was not found.
+        raise BlockNotFound("block with name '%s' does not exist" % block_name)
 
-def _render_template_block_nodelist(
-    nodelist: NodeList, block_name: str, context: Context
-) -> str:
-    """Recursively iterate over a node to find the wanted block."""
-
-    # Attempt to find the wanted block in the current template.
-    for node in nodelist:
-        # If the wanted block was found, return it.
-        if isinstance(node, BlockNode):
-            # No matter what, add this block to the rendering context.
-            context.render_context[BLOCK_CONTEXT_KEY].push(node.name, node)
-
-            # If the name matches, you're all set and we found the block!
-            if node.name == block_name:
-                return node.render(context)  # type: ignore[no-any-return]
-
-        # If a node has children, recurse into them. Based on
-        # django.template.base.Node.get_nodes_by_type.
-        for attr in node.child_nodelists:
-            try:
-                new_nodelist = getattr(node, attr)
-            except AttributeError:
-                continue
-
-            # Try to find the block recursively.
-            try:
-                return _render_template_block_nodelist(
-                    new_nodelist, block_name, context
-                )
-            except BlockNotFound:
-                continue
-
-    # The wanted block_name was not found.
-    raise BlockNotFound("block with name '%s' does not exist" % block_name)
+    return block_node.render(context)  # type: ignore[no-any-return]

--- a/tests/templates/test1.html
+++ b/tests/templates/test1.html
@@ -1,2 +1,2 @@
-{% block block1 %}block1 from test1{% endblock %}
-{% block block2 %}block2 from test1{% endblock %}
+{% block block1 %}block1 from test1{{ suffix1 }}{% endblock %}
+{% block block2 %}block2 from test1{{ suffix2 }}{% endblock %}

--- a/tests/templates/test4.html
+++ b/tests/templates/test4.html
@@ -1,1 +1,1 @@
-{% include 'test1.html' %}
+{% extends 'test2.html' %}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,7 +33,9 @@ class TestDjango(TestCase):
 
     def test_inherit_context(self) -> None:
         """This block is inherited from test1."""
-        result = render_block_to_string("test2.html", "block2", Context({"suffix2": " blah"}))
+        result = render_block_to_string(
+            "test2.html", "block2", Context({"suffix2": " blah"})
+        )
         self.assertEqual(result, "block2 from test1 blah")
 
     def test_multi_inherited(self) -> None:
@@ -43,7 +45,9 @@ class TestDjango(TestCase):
 
     def test_multi_inherited_context(self) -> None:
         """A block from an included template should be available."""
-        result = render_block_to_string("test4.html", "block2", Context({"suffix2": " blah"}))
+        result = render_block_to_string(
+            "test4.html", "block2", Context({"suffix2": " blah"})
+        )
         self.assertEqual(result, "block2 from test1 blah")
 
     def test_no_block(self) -> None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -55,6 +55,11 @@ class TestDjango(TestCase):
             result, "block2 from test6 - block2 from test3 - block2 from test1"
         )
 
+    def test_multi_inherited(self) -> None:
+        """A block from an included template should be available."""
+        result = render_block_to_string("test4.html", "block2")
+        self.assertEqual(result, "block2 from test1")
+
     def test_super_with_same_context_on_multiple_executions(self) -> None:
         """Test that block.super works when fed the same context object twice."""
         context = Context()
@@ -216,6 +221,12 @@ class TestJinja2(TestCase):
         self.assertEqual(
             result, "block2 from test6 - block2 from test3 - block2 from test1"
         )
+
+    @skip("Not currently supported.")
+    def test_multi_inherited(self) -> None:
+        """A block from an included template should be available."""
+        result = render_block_to_string("test4.html", "block2")
+        self.assertEqual(result, "block2 from test1")
 
     def test_subblock(self) -> None:
         """Test that a block within a block works."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -31,6 +31,21 @@ class TestDjango(TestCase):
         result = render_block_to_string("test2.html", "block2")
         self.assertEqual(result, "block2 from test1")
 
+    def test_inherit_context(self) -> None:
+        """This block is inherited from test1."""
+        result = render_block_to_string("test2.html", "block2", Context({"suffix2": " blah"}))
+        self.assertEqual(result, "block2 from test1 blah")
+
+    def test_multi_inherited(self) -> None:
+        """A block from an included template should be available."""
+        result = render_block_to_string("test4.html", "block2")
+        self.assertEqual(result, "block2 from test1")
+
+    def test_multi_inherited_context(self) -> None:
+        """A block from an included template should be available."""
+        result = render_block_to_string("test4.html", "block2", Context({"suffix2": " blah"}))
+        self.assertEqual(result, "block2 from test1 blah")
+
     def test_no_block(self) -> None:
         """Check if there's no block available an exception is raised."""
         with self.assertRaises(BlockNotFound) as exc:
@@ -54,11 +69,6 @@ class TestDjango(TestCase):
         self.assertEqual(
             result, "block2 from test6 - block2 from test3 - block2 from test1"
         )
-
-    def test_multi_inherited(self) -> None:
-        """A block from an included template should be available."""
-        result = render_block_to_string("test4.html", "block2")
-        self.assertEqual(result, "block2 from test1")
 
     def test_super_with_same_context_on_multiple_executions(self) -> None:
         """Test that block.super works when fed the same context object twice."""


### PR DESCRIPTION
Support inheriting over multiple levels of extends, e.g. template C extends template B extends template A and rendering a block from template A.

This *heavily* simplifies the code to avoid iterating the node list many times, although I'm not 100% confident I haven't broken any edge cases.

Fixes #12
Fixes #16
Fixes #45
Fixes #53