### PR TITLE
Add render_block function

### DIFF
--- a/render_block/__init__.py
+++ b/render_block/__init__.py
@@ -1,4 +1,14 @@
-from render_block.base import render_block_to_string
+from render_block.base import (
+    BlockOfTemplateResponse,
+    render_block,
+    render_block_to_string,
+)
 from render_block.exceptions import BlockNotFound, UnsupportedEngine
 
-__all__ = ["BlockNotFound", "UnsupportedEngine", "render_block_to_string"]
+__all__ = [
+    "BlockNotFound",
+    "BlockOfTemplateResponse",
+    "UnsupportedEngine",
+    "render_block",
+    "render_block_to_string",
+]

--- a/render_block/base.py
+++ b/render_block/base.py
@@ -91,7 +91,10 @@ def render_block(
 
 
 class BlockOfTemplateResponse(TemplateResponse):
-    """This class implements a TemplateResponse that only renders a block from the template."""
+    """
+    This class implements a TemplateResponse that only renders a block from the
+    template.
+    """
 
     def __init__(
         self,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,4 +29,7 @@ MIDDLEWARE_CLASSES: tuple = tuple()
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
 INSTALLED_APPS = ("tests",)
+
 AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
+
+ROOT_URLCONF = "tests.urls"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from tests import views
+
+urlpatterns = [
+    path("block", views.BlockView.as_view(), name="block"),
+]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,27 @@
+from django.http import HttpResponse
+from django.views import View
+
+from render_block import render_block
+
+
+class BlockView(View):
+    """
+    This view simply calls render_block with parameters from the data of the request.
+    """
+
+    def post(self, request) -> HttpResponse:
+        context = {
+            key: request.POST.get(key)
+            for key in request.POST.keys()
+            if key not in ("template_name", "block_name")
+        }
+        if context == {}:
+            context = None
+
+        return render_block(
+            request,
+            template_name=request.POST.get("template_name"),
+            block_name=request.POST.get("block_name"),
+            context=context,
+            status=request.POST.get("status"),
+        )


### PR DESCRIPTION
This pull request adds the `render_block()` function that returns an `HttpResponse` with the block.
It also allows to verify the context that was passed to `render_block()` in unit tests.

Closes #59
