### PR TITLE
Support Django 5.2 & Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,17 @@
 Changelog
 #########
 
+next
+====
+
+Maintenance
+-----------
+
+* Support Python 3.13.
+* Drop support for Python 3.8.
+* Support Django 5.2.
+* Drop support for Django 5.0.
+
 0.10 (July 15, 2024)
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,10 @@ next
 Maintenance
 -----------
 
-* Support Python 3.13.
-* Drop support for Python 3.8.
-* Support Django 5.2.
-* Drop support for Django 5.0.
+* Support Python 3.13. (`#62 <https://github.com/clokep/django-render-block/pull/62>`_)
+* Drop support for Python 3.8. (`#62 <https://github.com/clokep/django-render-block/pull/62>`_)
+* Support Django 5.2. (`#62 <https://github.com/clokep/django-render-block/pull/62>`_)
+* Drop support for Django 5.0. (`#62 <https://github.com/clokep/django-render-block/pull/62>`_)
 
 0.10 (July 15, 2024)
 ====================

--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ Features
 Requirements
 ============
 
-Django Render Block supports Django 4.2, 5.0, and 5.1 on Python 3.8, 3.9, 3.10,
-3.11 and 3.12 (see the Django documentation for which versions of Python are
-supported by particular Django versions).
+Django Render Block supports Django 4.2, 5.1, and 5.2 on Python 3.9, 3.10, 3.11,
+3.12, and 3.13 (see the `Django documentation <https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django>`_
+for which versions of Python are supported by particular Django versions).
 
 Examples
 ========

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,14 +17,15 @@ classifiers =
     Environment :: Web Environment
     Topic :: Internet
     Framework :: Django
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
+    Framework :: Django :: 5.1
+    Framework :: Django :: 5.2
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: ISC License (ISCL)
 project_urls =
     Documentation = https://github.com/clokep/django-render-block/blob/main/README.rst

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,11 @@
 
 [tox]
 envlist =
-    py{38,39,310,311,312}-django42,
-    # Django 5.0 drops support for Python 3.8 and 3.9.
-    py{310,311,312}-django{50,51,main},
-    # Django 4.1.3 adds support for Python 3.11.
-    py311-django{41,42,main}
+    # See https://www.djangoproject.com/download/#supported-versions
+    # See https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
+    py{39,310,311,312}-django42,
+    py{310,311,312,313}-django{51,52},
+    py{312,313}-djangomain
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -18,7 +18,7 @@ commands =
     python manage.py test
 deps =
     Jinja2
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django51: Django>=5.1b1,<5.2
+    django42: Django>=4.2.8,<4.3
+    django51: Django>=5.1.3,<5.2
+    django52: Django>=5.2,<5.3
     djangomain: https://codeload.github.com/django/django/zip/main


### PR DESCRIPTION
And drop support for Django 5.0 and Python 3.8, which are both EOL.