### PR TITLE
Have wheel advertise availability of type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ packages =
 install_requires = django>=4.2
 python_requires = >=3.9
 
+[options.package_data]
+render_block = py.typed
+
 [options.extras_require]
 dev =
     Jinja2>=2.8


### PR DESCRIPTION
Currently `django-render-block` includes type annotations, but these are ignored when type-checking an application that uses this library. By including the `py.typed` marker file in the wheel, type checkers like `mypy` can check whether applications call `django-render-block` with the correct types.

https://www.python.org/dev/peps/pep-0561/#packaging-type-information